### PR TITLE
Added process.env fallbacks for Windows

### DIFF
--- a/bin/vault
+++ b/bin/vault
@@ -9,7 +9,7 @@ var CLI  = require('../node/cli'),
     key  = process.env.VAULT_KEY ||
            process.env.LOGNAME ||
            process.env.USER ||
-           processe.nv.USERNAME;
+           process.env.USERNAME;
 
 if (!/^\//.test(path)) {
   path = (process.env.HOME || process.env.USERPROFILE) + '/' + path;


### PR DESCRIPTION
- Added `process.env.USERNAME` as a key fallback
- Added `process.env.USERPROFILE` as a root path fallback

The check for `path` starting with `/` isn't strictly correct, but works for the default `path = '.vault'` - this is the minimum I had to do to successfully run the CLI version of Vault on Windows.
