### PR TITLE
Use explicit version number for jsclass library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
                       , "ssh-agent": "~0.2.1"
                       , "vault-cipher": "~0.3.0"
                       }
-, "devDependencies" : { "jsclass": "" }
+, "devDependencies" : { "jsclass": "~3.0.9" }
 
 , "scripts"         : { "postinstall" : "./node/scripts/postinstall"
                       , "test"        : "node spec/node.js"


### PR DESCRIPTION
The latest version of jsclass causes the test to fail.
Ref: https://travis-ci.org/theskumar/vault/builds/10708531
