### PR TITLE
Relay error in key selection to user.

### DIFF
--- a/node/cli.js
+++ b/node/cli.js
@@ -86,7 +86,8 @@ CLI.prototype.run = function(argv, callback, context) {
     if (params.export) return this.export(params.export, callback, context);
     if (params.import) return this.import(params.import, callback, context);
 
-    this.withPhrase(params, function() {
+    this.withPhrase(params, function(error) {
+      if (error) return callback.call(context, error);
       if (params.config) {
         delete params.config;
         this.configure(service, params, callback, context);


### PR DESCRIPTION
My SSH agent is only forwarding my DSA key (not my RSA) for whatever reason. This results in a
"no RSA keys" error but its swallowed, leaving me with this message instead:

```
$ ./bin/vault steam -k
No passphrase given; pass `-p` or run `vault -cp`
```

With this change, this error is shown:

```
$ ./bin/vault steam -k
No usable RSA keys were found
```
