### PR TITLE
web: select password field contents on focus

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -127,3 +127,13 @@ on(phrase, 'keydown', function(e) {
   if (e.keyCode === 13) insert();
 });
 
+var wordFocused = false;
+on(word, 'focus', function(e) {
+  wordFocused = true;
+});
+on(word, 'blur', function(e) {
+  wordFocused = false;
+});
+on(word, 'mouseup', function(e) {
+  if (wordFocused) word.setSelectionRange(0, word.value.length);
+});


### PR DESCRIPTION
I'm running a Vault of my very own on https://v.wjt.me.uk/ and took the chance to fix a papercut that bothers me every time I use it.

It's no help on Android – the text is selected but the edit bar doesn't come up so it can't be copied – but it seems to work fine on desktop.
