### PR TITLE
Fix vault-cipher submodule for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ node_js:
   - "0.10"
   - "0.11"
 
+before_install:
+  - mkdir node_modules
+  - git clone https://github.com/jcoglan/vault-cipher.git node_modules/vault-cipher


### PR DESCRIPTION
Hi! This is one way to fix the CI on not-yet-released versions. I will shortly send another.
