### PR TITLE
Workaround node-pw eating Ctrl-C / SIGINT.

### DIFF
--- a/bin/vault
+++ b/bin/vault
@@ -26,6 +26,18 @@ var readline = (parseInt(version[2], 10) <= 6)
                  return rl.createInterface({input: process.stdin, output: process.stderr});
                };
 
+// node-pw exits with success on ^C which is awful. Intercepting that
+// and exiting with an error so scripts work is slightly less awful.
+// https://github.com/substack/node-pw/pull/6
+function intercept_interrupt(code) {
+  // If intercepting some other abnormal exit, don't mess with it.
+  if (code === 0) {
+    // SIGINT is signal 2 on most (not all) POSIX systems, which
+    // means exit code 130 if exiting due to a signal.
+    process.exit(130);
+  }
+}
+
 var cli = new CLI({
   config: {path: path, key: key},
   stdout: process.stdout,
@@ -42,7 +54,9 @@ var cli = new CLI({
 
   password: function(callback) {
     process.stderr.write('Passphrase: ');
+    process.on('exit', intercept_interrupt);
     pw('*', process.stdin, process.stderr, function(password) {
+      process.removeListener('exit', intercept_interrupt);
       password = new Buffer(password, 'binary').toString('utf8');
       callback(password);
     });


### PR DESCRIPTION
node-pw exits with code 0 (success) if you press Ctrl-C while entering your password. This is awful.

This installs a process exit handler for the duration of the password prompt that catches exiting with code 0 and instead exits with code 130. This is very slightly less awful.

There's a good chance you won't want this because it is a gross gross thing, but I need it for vault to work properly in shell scripts, and figured I might as well let you know node-pw is terrible. I've already filed https://github.com/substack/node-pw/pull/6 with a proper fix but it also seems dead.
