### PR TITLE
Fix TypeError caused by inactive ssh-agent

### DIFF
--- a/bin/vault
+++ b/bin/vault
@@ -53,7 +53,7 @@ var cli = new CLI({
         snip   = 12;
 
     client.requestIdentities(function(error, keys) {
-      if (keys === undefined)
+      if (error || keys === undefined)
         return callback(new Error('No keys were found'));
 
       keys = keys.filter(function(k) { return k.type === 'ssh-rsa' });
@@ -82,6 +82,9 @@ var cli = new CLI({
   sign: function(sshKey, message, callback) {
     var client = new SSH();
     client.requestIdentities(function(error, keys) {
+      if (error || keys === undefined)
+        return callback(new Error('No keys were found'))
+
       var key = keys.filter(function(k) { return k.ssh_key === sshKey })[0];
       if (!key) return callback(new Error('Private key not found'));
 

--- a/bin/vault
+++ b/bin/vault
@@ -53,6 +53,9 @@ var cli = new CLI({
         snip   = 12;
 
     client.requestIdentities(function(error, keys) {
+      if (keys === undefined)
+        return callback(new Error('No keys were found'));
+
       keys = keys.filter(function(k) { return k.type === 'ssh-rsa' });
 
       if (keys.length === 0)


### PR DESCRIPTION
`SSH#requestIdentities` returns `undefined` if `ssh-agent` isn’t active, so the unguarded call to `keys.filter` throws a `TypeError`. Adding a guard, `vault` with `--key` without an inactive `ssh-agent` now responds with the expected (albeit not particularly helpful) “no passphrase given” instead of a stack trace.
